### PR TITLE
Add support for nested view controllers

### DIFF
--- a/JSSAlertView.swift
+++ b/JSSAlertView.swift
@@ -247,7 +247,7 @@ class JSSAlertView: UIViewController {
     
     func show(viewController: UIViewController, title: String, text: String?=nil, buttonText: String?=nil, cancelButtonText: String?=nil, color: UIColor?=nil, iconImage: UIImage?=nil) -> JSSAlertViewResponder {
         
-        self.rootViewController = viewController
+        self.rootViewController = viewController.view.window!.rootViewController
         self.rootViewController.addChildViewController(self)
         self.rootViewController.view.addSubview(view)
         


### PR DESCRIPTION
Currently, the alert view does not work properly when there are additional navigation/tab bar controllers. This guarantees the alert view is added to the true root controller, therefore performing correctly.

The code fix seems a bit extraneous to me, so if anyone else knows of a better way, I'd love to know