### PR TITLE
Fixed cancel behavior

### DIFF
--- a/JSSAlertView.swift
+++ b/JSSAlertView.swift
@@ -393,25 +393,23 @@ class JSSAlertView: UIViewController {
                 UIView.animateWithDuration(0.1, animations: {
                     self.view.alpha = 0
                     }, completion: { finished in
-                        if withCallback == true {
+                        if withCallback {
                             if let action = self.closeAction where source == .Close {
                                 action()
                             }
+                            else if let action = self.cancelAction where source == .Cancel {
+                                action()
+                            }
                         }
-                        self.removeView(withCallback, source: source)
+                        self.removeView()
                 })
                 
         })
     }
     
-    func removeView(withCallback:Bool, source:ActionType = .Cancel) {
+    func removeView() {
         isAlertOpen = false
         self.view.removeFromSuperview()
-        if withCallback {
-            if let action = self.cancelAction where source == .Cancel {
-                action()
-            }
-        }
     }
     
 }

--- a/JSSAlertView.swift
+++ b/JSSAlertView.swift
@@ -44,6 +44,10 @@ class JSSAlertView: UIViewController {
     var darkTextColor = UIColorFromHex(0x000000, alpha: 0.75)
     var lightTextColor = UIColorFromHex(0xffffff, alpha: 0.9)
     
+    enum ActionType {
+        case Close, Cancel
+    }
+    
     let baseHeight:CGFloat = 160.0
     var alertWidth:CGFloat = 290.0
     let buttonHeight:CGFloat = 70.0
@@ -371,7 +375,7 @@ class JSSAlertView: UIViewController {
     }
     
     func buttonTap() {
-        closeView(true);
+        closeView(true, source: .Close);
     }
     
     func addCancelAction(action: ()->Void) {
@@ -379,10 +383,10 @@ class JSSAlertView: UIViewController {
     }
 
     func cancelButtonTap() {
-        closeView(false);
+        closeView(true, source: .Cancel);
     }
     
-    func closeView(withCallback:Bool) {
+    func closeView(withCallback:Bool, source:ActionType = .Close) {
         UIView.animateWithDuration(0.3, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.5, options: nil, animations: {
             self.containerView.center.y = self.rootViewController.view.center.y + self.viewHeight!
             }, completion: { finished in
@@ -390,21 +394,23 @@ class JSSAlertView: UIViewController {
                     self.view.alpha = 0
                     }, completion: { finished in
                         if withCallback == true {
-                            if let action = self.closeAction {
+                            if let action = self.closeAction where source == .Close {
                                 action()
                             }
                         }
-                        self.removeView()
+                        self.removeView(withCallback, source: source)
                 })
                 
         })
     }
     
-    func removeView() {
+    func removeView(withCallback:Bool, source:ActionType = .Cancel) {
         isAlertOpen = false
         self.view.removeFromSuperview()
-        if let action = self.cancelAction? {
-            action()
+        if withCallback {
+            if let action = self.cancelAction where source == .Cancel {
+                action()
+            }
         }
     }
     

--- a/JSSAlertViewExample/JSSAlertViewExample/ViewController.swift
+++ b/JSSAlertViewExample/JSSAlertViewExample/ViewController.swift
@@ -65,21 +65,26 @@ class ViewController: UIViewController {
     
     @IBAction func twoButtonAlertPress() {
         var alertview = JSSAlertView().show(self, title: "Standard alert", text: "A standard alert with some text looks like this", buttonText: "Yep", cancelButtonText: "Nope")
-        alertview.addAction(callback)
+        alertview.addAction(closeCallback)
+        alertview.addCancelAction(cancelCallback)
     }
     
     @IBAction func kitchenSinkAlertViewButtonPress() {
         var customIcon = UIImage(named: "lightbulb")
         var alertview = JSSAlertView().show(self, title: "Kitchen sink", text: "Here's a modal alert with descriptive text, an icon, custom fonts and a custom color", buttonText: "Sweet", color: UIColorFromHex(0xE0107A, alpha: 1), iconImage: customIcon)
-        alertview.addAction(callback)
+        alertview.addAction(closeCallback)
         alertview.setTitleFont("ClearSans-Bold")
         alertview.setTextFont("ClearSans")
         alertview.setButtonFont("ClearSans-Light")
         alertview.setTextTheme(.Light)
     }
     
-    func callback() {
-        println("Callback called")
+    func closeCallback() {
+        println("Close callback called")
+    }
+    
+    func cancelCallback() {
+        println("Cancel callback called")
     }
     
 }

--- a/README.md
+++ b/README.md
@@ -58,16 +58,20 @@ alertview.setButtonFont("ClearSans-Light") // Button text font
 alertview.setTextTheme(.Light) // can be .Light or .Dark
 ```
 
-Finally, two-button alerts with a cancel button on the left are possible by passing in some `cancelButtonText`. The button on the left side of the alert will reflect that text and simply dismiss the alert when tapped. The right-hand button will trigger any callbacks specified as well as dismissing the alert.
+Finally, two-button alerts with a cancel button on the left are possible by passing in some `cancelButtonText`. The button on the left side of the alert will reflect that text and simply dismiss the alert when tapped, with an optional cancel callback. The right-hand button will also dismiss the alert as usual, with the appropriate close callback if present.
 
 ```swift
-JSSAlertView().show(
+func myCancelCallback() {
+  // this'll run if cancel is pressed after the alert is dismissed
+}
+var alertview = JSSAlertView().show(
   self, 
   title: "I'm an alert",
   text: "An alert with two buttons. Dismiss by tapping the left, and do something else by tapping the right.", 
-  buttonText: "Trigger callback",
-  cancelButtonText: "Just dismiss alert" // This tells JSSAlertView to create a two-button alert
+  buttonText: "OK",
+  cancelButtonText: "Cancel" // This tells JSSAlertView to create a two-button alert
 )
+alertview.addCancelAction(myCancelCallback)
 ```
 
 See the included example project for more!


### PR DESCRIPTION
Previously, the `cancelAction` would run regardless of which button was pressed. This separates the two actions entirely; only one callback will be fired depending on which button is pressed.

I also improved the logic of where the cancel callback gets fired & added documentation for it to the README.

Fixes #13 